### PR TITLE
Land detector

### DIFF
--- a/scripts/crazyflie_controller_bridge.py
+++ b/scripts/crazyflie_controller_bridge.py
@@ -60,7 +60,6 @@ class ControllerBridge:
             sp.linear = self.target_setpoint.linear
             if self.landing:
                 sp.linear.z = -1
-                print(self.landing_ticks, self.curr_z_vel)
                 if abs(self.curr_z_vel) < 0.4:
                     self.landing_ticks += 1
                     if self.landing_ticks >= 0.5*UPDATE_RATE:

--- a/scripts/log_range.py
+++ b/scripts/log_range.py
@@ -4,15 +4,15 @@
 # range0..5, status
 import rospy
 from bitcraze_lps_estimator.msg import RangeArray
-from crazyflie_driver.msg import GenericLogData
+from std_msgs.msg import Float32MultiArray
 
 
 def callback(data):
     ranging = RangeArray()
 
-    ranging.ranges = data.values[:6]
+    ranging.ranges = data.data[:6]
 
-    state = int(data.values[6])
+    state = int(data.data[6])
     valid = [False] * 6
     for i in range(6):
         valid[i] = (state & (1 << i)) != 0
@@ -26,6 +26,6 @@ if __name__ == "__main__":
     ranging_pub = rospy.Publisher("ranging", RangeArray, queue_size=10)
 
     rospy.Subscriber(rospy.get_namespace()+"log_ranges",
-                     GenericLogData, callback)
+                     Float32MultiArray, callback)
 
     rospy.spin()

--- a/scripts/lps_ekf_bridge.py
+++ b/scripts/lps_ekf_bridge.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     rospy.wait_for_service('update_params')
     update_params = rospy.ServiceProxy('update_params', UpdateParams)
 
-    enabled = rospy.get_param("anchor_pos.enable")
+    enabled = rospy.get_param("anchorpos/enable")
     if enabled == False:
         rospy.loginfo("Setting anchor position ...")
         n_anchors = rospy.get_param("n_anchors")

--- a/scripts/lps_ekf_bridge.py
+++ b/scripts/lps_ekf_bridge.py
@@ -7,10 +7,9 @@ import rospy
 from geometry_msgs.msg import PoseStamped
 from geometry_msgs.msg import Point
 from crazyflie_driver.srv import UpdateParams
+from std_msgs.msg import Float32MultiArray
 
 import tf
-
-from crazyflie_driver.msg import GenericLogData
 
 ps = PoseStamped()
 ps.pose.orientation.w = 1
@@ -23,9 +22,9 @@ ps.pose.position.z = 0
 
 
 def callback_pos(data):
-    ps.pose.position.x = data.values[0]
-    ps.pose.position.y = data.values[1]
-    ps.pose.position.z = data.values[2]
+    ps.pose.position.x = data.data[0]
+    ps.pose.position.y = data.data[1]
+    ps.pose.position.z = data.data[2]
     ps.header.frame_id = "/world"
     ps.header.stamp = rospy.Time.now()
 
@@ -46,10 +45,10 @@ def callback_pos(data):
 
 
 def callback_qt(data):
-    ps.pose.orientation.w = data.values[0]
-    ps.pose.orientation.x = data.values[1]
-    ps.pose.orientation.y = data.values[2]
-    ps.pose.orientation.z = data.values[3]
+    ps.pose.orientation.w = data.data[0]
+    ps.pose.orientation.x = data.data[1]
+    ps.pose.orientation.y = data.data[2]
+    ps.pose.orientation.z = data.data[3]
 
 if __name__ == "__main__":
     rospy.init_node('lps_ekf_bridge')
@@ -63,20 +62,21 @@ if __name__ == "__main__":
     rospy.wait_for_service('update_params')
     update_params = rospy.ServiceProxy('update_params', UpdateParams)
 
-    rospy.loginfo("Setting anchor position ...")
+    enabled = rospy.get_param("anchor_pos.enable")
+    if enabled == False:
+        rospy.loginfo("Setting anchor position ...")
+        n_anchors = rospy.get_param("n_anchors")
+        for i in range(n_anchors):
+            position = rospy.get_param("anchor{}_pos".format(i))
+            rospy.loginfo("Anchor {} at {}".format(i, position))
+            name = "anchorpos/anchor{}".format(i)
+            rospy.set_param(name + "x", position[0])
+            rospy.set_param(name + "y", position[1])
+            rospy.set_param(name + "z", position[2])
+            update_params([name + 'x', name + 'y', name + 'z'])
 
-    n_anchors = rospy.get_param("n_anchors")
-    for i in range(n_anchors):
-        position = rospy.get_param("anchor{}_pos".format(i))
-        rospy.loginfo("Anchor {} at {}".format(i, position))
-        name = "anchorpos/anchor{}".format(i)
-        rospy.set_param(name + "x", position[0])
-        rospy.set_param(name + "y", position[1])
-        rospy.set_param(name + "z", position[2])
-        update_params([name + 'x', name + 'y', name + 'z'])
-
-    rospy.Subscriber("log_kfpos", GenericLogData, callback_pos)
-    rospy.Subscriber("log_kfqt", GenericLogData, callback_qt)
+    rospy.Subscriber("log_kfpos", Float32MultiArray, callback_pos)
+    rospy.Subscriber("log_kfqt", Float32MultiArray, callback_qt)
     if rospy.has_param("anchorpos/enable"):
         rospy.set_param("anchorpos/enable", 1)
         update_params(["anchorpos/enable"])


### PR DESCRIPTION
This PR will get updated to be against the bitcraze/lps-ros reposity, but after the add_quaternion_to_cf_tf branch has been merged due to a dependency.

* Change log type to a Float32MultiArray which allows much easier plotting of data (in rqt_plot for example), as it is encoded as floats instead of string of a literal list
* Only send anchor positions if it isn't already enabled on the crazyflie
* Add a basic land detector which uses the Z velocity, landed command, and a timer to determine if the crazyflie has landed

Depends on bitcraze/crazyflie-firmware#161 and whoenig/crazyflie_ros#49